### PR TITLE
fix: remove capabilities from canceled licenses

### DIFF
--- a/lib/__tests__/getUser.test.ts
+++ b/lib/__tests__/getUser.test.ts
@@ -25,6 +25,15 @@ describe('getUser', () => {
     expect(capabilities).toMatchObject([{ name: 'create', status: 'ACTIVE' }])
   })
 
+  it('excludes capabilities on canceled licenses from list', async () => {
+    const { capabilities } = await getUser({
+      ...baseGetUserValues,
+      granteeId: 'test-user-1',
+    })
+
+    expect(capabilities).not.toMatchObject([{ name: 'notify' }])
+  })
+
   it('filters out products that do not match the provided productUuid', async () => {
     const { licenses, capabilities } = await getUser({
       productUuid: 'test',
@@ -68,6 +77,15 @@ describe('getUser', () => {
         edit: false,
         create: true,
       })
+    })
+
+    it('returns false for capabilities on canceled licenses', async () => {
+      const { hasCapability } = await getUser({
+        ...baseGetUserValues,
+        granteeId: 'test-user-1',
+      })
+
+      expect(hasCapability('notify')).toEqual(false)
     })
   })
 })

--- a/lib/__tests__/getUserData.ts
+++ b/lib/__tests__/getUserData.ts
@@ -63,6 +63,34 @@ const mockResponseData = [
     updatedAt: '2019-08-24T14:15:22Z',
     isTest: true,
   },
+  {
+    uuid: '095be615-a8ad-4c33-8e9c-c7612fbf6c9g',
+    productUuid: '3a88375a-5ea7-4e22-b7fe-b3c10f9367f3',
+    planUuid: '4da9429c-fce6-4d7f-97f3-072e42f5878c',
+    subscriptionUuid: '466672c4-1527-4594-82f2-3d3ac972eb69',
+    granteeId: 'test-user-1',
+    purchaser: 'purchaser-2@example.com',
+    email: 'user@example.com',
+    name: 'John Doe',
+    paymentService: 'Stripe',
+    type: 'Renew',
+    capabilities: [
+      {
+        uuid: '095be615-a8ad-4c33-8e9c-c7612fbf6c9f',
+        name: 'notify',
+        description: 'Allows a user to create something',
+        status: 'ACTIVE',
+        productUuid: '3a88375a-5ea7-4e22-b7fe-b3c10f9367f3',
+        updatedAt: '2019-08-24T14:15:22Z',
+      },
+    ],
+    startTime: '2019-08-24T14:15:22Z',
+    endTime: '2019-08-24T14:15:22Z',
+    status: 'CANCELED',
+    metadata: 'string',
+    updatedAt: '2019-08-24T14:15:22Z',
+    isTest: true,
+  },
 ]
 
 export { mockResponseData }

--- a/lib/getUser.ts
+++ b/lib/getUser.ts
@@ -42,9 +42,10 @@ export type UserData = {
    * Used to check whether a user has either an active capability, or a list of
    * supplied capabilities. Capability names are case insensitive.
    *
-   * All inactive capabilities will return false. If you want to check against a
-   * capability that isn't active, use the `capabilities` array returned by this
-   * hook.
+   * All inactive capabilities will return false. This includes capabilities
+   * that are on 'canceled' licenses. If you want to check for a capability
+   * that isn't active, or is on a canceled license, use the `capabilities`
+   * array returned by this hook.
    *
    * To check a single capability:
    * ```
@@ -82,13 +83,15 @@ async function _getUser({
     (license) => license.productUuid === productUuid,
   )
 
-  const capabilities = licenses.flatMap(
-    (license) =>
-      license.capabilities.flatMap((capability) => ({
-        name: capability.name,
-        status: capability.status,
-      })) ?? [],
-  )
+  const capabilities = licenses
+    .filter((license) => license.status === 'ACTIVE')
+    .flatMap(
+      (license) =>
+        license.capabilities.flatMap((capability) => ({
+          name: capability.name,
+          status: capability.status,
+        })) ?? [],
+    )
 
   // Overload for checking an individual capability.
   function hasCapability(capability: string): boolean


### PR DESCRIPTION
BREAKING CHANGE: capabilities on canceled licenses are now ignored

### JIRA Ticket(s):

- N/A

### Overview

Prior to this change, both the `capabilities` array and the `hasCapability` utility returned by the `getUser` fn would utilise capabilities on cancelled licenses. This wasn't intentional and not something that we want.

Now, if a capability belongs to a cancelled license, it will always `hasCapability() = false` and not be included in the list.

### Collaborators

N/A

### Standards

- [x] Updated relevant documentation.
- [x] Added sufficient tests.
- [x] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

### Considerations

N/A
